### PR TITLE
makes map_availability() work

### DIFF
--- a/R/instructor_training.R
+++ b/R/instructor_training.R
@@ -36,7 +36,7 @@ map_availability <- function(dat) {
   )
   # The regex pattern matches both spaces and dots
   matching_cols <-
-    grepl("available[\\.\\s]to[\\.\\s]teach",
+    grepl("Are[\\.\\s]you[\\.\\s]available[\\.\\s]to[\\.\\s]teach",
           names(dat),
           ignore.case = TRUE)
 


### PR DESCRIPTION
The goal of this PR is to make the `map_availability()` function able to work using a dataframe created from the response spreadsheets that are generated from the Trainer Availability form. Currently, the `grepl` call is too gregarious and matches multiple columns in the spreadsheet, making `map_availability()` throw an error. This makes the `grepl` call more specific so it only matches the column with the "Are you available to teach . . . " question and not the columns like "How many events would you be available to teach from . . .". From a cursory glance, it appears that this change will make `map_availability()` work with all existing quarters of data from the Trainer Availability form. 

